### PR TITLE
Add command line argument in CI

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -34,4 +34,4 @@ jobs:
     - name: Build
       run: cabal build --enable-tests --enable-benchmarks all
     - name: Run tests
-      run: cabal test --enable-tests --enable-benchmarks all
+      run: cabal test --enable-tests --enable-benchmarks all --test-options --environment=env


### PR DESCRIPTION
テストで要求されているコマンドライン引数がないことからCIが落ちていたので、cabal testにコマンドライン引数を与えることでテストが通るように修正しました。