### PR TITLE
Add `errorLogger` function

### DIFF
--- a/src/Panfiguration.hs
+++ b/src/Panfiguration.hs
@@ -9,6 +9,7 @@ module Panfiguration (
     defaults,
     fullDefaults,
     logger,
+    errorLogger,
     run,
     -- * Naming convention
     Case(..),

--- a/tests/test.hs
+++ b/tests/test.hs
@@ -27,6 +27,7 @@ deriving instance Show ServerArgs
 getServerArgs :: IO ServerArgs
 getServerArgs = run $ mconcat
     [ logger putStrLn
+    , errorLogger (putStrLn . ("[Error] "++))
     , declCase snake
     , opts `asCase` kebab
     , envs


### PR DESCRIPTION
errorLogger関数を追加し、環境変数が存在しない場合やパースエラーが発生した場合にerrorLoggerで指定したロガーを使用するように変更しました。loggerが設定されておりかつerrorLoggerが未設定の場合はloggerが使用されます。